### PR TITLE
fix: remove syn clear for compatibility

### DIFF
--- a/autoload/AnsiEsc.vim
+++ b/autoload/AnsiEsc.vim
@@ -128,7 +128,7 @@ fun! AnsiEsc#AnsiEsc(rebuild)
    endif
   endif
 
-  syn clear
+  " syn clear
 
   if has("conceal")
    syn match ansiConceal		contained conceal	"\e\[\(\d*;\)*\d*[A-Za-z]"


### PR DESCRIPTION
Allows other `syn` based plugins to work alongside this one.